### PR TITLE
#REFACTOR Ueberfluessige Methoden aus Konnektoren entfernt

### DIFF
--- a/DataConnectors/AbstractUrlConnector.php
+++ b/DataConnectors/AbstractUrlConnector.php
@@ -30,26 +30,6 @@ abstract class AbstractUrlConnector extends AbstractDataConnectorWithoutTransact
      *
      * {@inheritdoc}
      *
-     * @see \exface\Core\CommonLogic\AbstractDataConnector::getInsertId()
-     */
-    function getInsertId()
-    {
-        // TODO
-        return 0;
-    }
-
-    /**
-     */
-    function getAffectedRowsCount()
-    {
-        // TODO
-        return 0;
-    }
-
-    /**
-     *
-     * {@inheritdoc}
-     *
      * @see \exface\Core\CommonLogic\AbstractDataConnector::getLastError()
      */
     function getLastError($conn = NULL)

--- a/DataConnectors/HttpConnector.php
+++ b/DataConnectors/HttpConnector.php
@@ -133,12 +133,6 @@ class HttpConnector extends AbstractUrlConnector
         return $query;
     }
 
-    function getInsertId()
-    {
-        // TODO
-        return 0;
-    }
-
     public function getUser()
     {
         return $this->user;


### PR DESCRIPTION
Die obsoloten Methoden getInsertId() und getAffectedRowsCount() wurden aus AbstractUrlConnector und HttpConnector entfernt.