### PR TITLE
FIX Error unknown function, warning in AbstractUrlBuilder

### DIFF
--- a/QueryBuilders/AbstractUrlBuilder.php
+++ b/QueryBuilders/AbstractUrlBuilder.php
@@ -277,7 +277,7 @@ abstract class AbstractUrlBuilder extends AbstractQueryBuilder
      */
     public function addFilterCondition(Condition $condition)
     {
-        $qpart = parent::addCondition($condition);
+        $qpart = parent::addFilterCondition($condition);
         $this->prepareFilter($qpart);
         return $qpart;
     }
@@ -318,7 +318,7 @@ abstract class AbstractUrlBuilder extends AbstractQueryBuilder
      * {@inheritDoc}
      * @see \exface\Core\CommonLogic\QueryBuilder\AbstractQueryBuilder::addSorter()
      */
-    public function addSorter($sort_by, $order) {
+    public function addSorter($sort_by, $order = 'ASC') {
         $qpart = parent::addSorter($sort_by, $order);
         $this->prepareSorter($qpart);
         return $qpart;


### PR DESCRIPTION
Es gab einen Fehler dass eine nicht existierende Funktion aufgerufen wurde (addFilterCondition), und eine Warnung dass die Deklarationen uebereinstimmen sollten (addSorter).
